### PR TITLE
Implement Merkle sync manifest flow

### DIFF
--- a/docs/sync_refactor_plan.md
+++ b/docs/sync_refactor_plan.md
@@ -1,0 +1,45 @@
+# Sync Logic Refactor Plan
+
+## 1. Scope & Context
+- Client: `index.html`, `railway_client.js`, `data_manager.js`
+- Server: `railway-server/server.js`
+- Existing flow: clients post to `/api/submit-answer`, server persists and broadcasts `answer_submitted`; clients fetch history via `/api/peer-data?since=`.
+
+## 2. Functional Goals
+- Partition data with a two-level Merkle-style structure: first by curriculum unit, then by lesson within that unit.
+- Maintain cached manifests: `unitId -> unitHash` and `unitId -> { lessonId -> lessonHash }`, recomputing only affected unit/lesson on updates.
+- Primary failure mode: holes from missed WebSocket messages; secondary: unnecessary data transfer. Two-level hashes ensure the initial scan is light while lesson-level resyncs stay narrow.
+
+## 3. Interfaces & Protocols
+- New endpoints:
+  - `GET /api/sync/manifest` → `{ units: [{ unitId, hash }] }` for the top-level unit hashes.
+  - `GET /api/sync/unit/<unitId>` → `{ lessons: [{ lessonId, hash }] }` for a specific unit’s lesson hashes when the unit hash mismatches.
+  - `GET /api/data/lesson/<lessonId>` → canonical ordered answers for that lesson.
+- WebSocket `answer_submitted` payload includes `unitId`, `lessonId`, new answer, and updated unit hash so listening clients can decide whether to fetch lesson manifests immediately.
+- Client workflow:
+  1. Fetch unit manifest on connect and at polling intervals.
+  2. Compare server unit hashes with local digests; for mismatched units fetch the lesson manifest.
+  3. Request only lessons whose hashes mismatch via `GET /api/data/lesson/<lessonId>` and merge using `data_manager`.
+
+## 4. Operational Concerns
+- Cache structure: `{ answersByLesson, lessonHashesByUnit, unitHashes, lastUpdated }` stored in-memory; recompute only the affected lesson hash and then its parent unit hash on submission.
+- Hashing: canonicalize lesson payloads (sorted by student, question, timestamp) before hashing. Use `crypto.createHash('md5')` to satisfy the no-build-step/CommonJS constraint while keeping hashing fast.
+- Limit concurrent lesson resyncs to avoid burst load; exponential backoff on retries.
+- Logging: emit checksum mismatches, resync requests, recompute durations, and manifest fetch metrics.
+
+## 5. Testing & Verification
+- Server unit tests implemented in `railway-server/test.js` using `assert` to cover canonicalization, MD5 hash stability, and cache invalidation logic.
+- Integration test script to replay submissions against the server and verify WebSocket payloads include updated hashes.
+- Simulated disconnect test: drop WebSocket events in the browser and confirm manifest polling triggers targeted lesson resyncs.
+- Performance spot-check: seed with 10k answers, ensure `GET /api/sync/manifest` returns in <50 ms and lesson fetches stay narrow.
+
+## 6. Additional Requirements
+- Type-safe helpers (JSDoc) for payload shapes to reduce drift.
+- Document protocol in `/docs/sync_refactor_plan.md` and share with client team.
+- No new external dependencies without review.
+
+## Next Steps
+1. Implement server-side lesson + unit hash cache and the three sync/data endpoints.
+2. Update client data manager to track unit and lesson digests.
+3. Wire WebSocket broadcasts, manifest polling, and targeted lesson reconciliation.
+4. Add `test.js`, document manual disconnect procedure, and update deployment checklist.

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <script src="railway_config.js"></script>
     <script src="js/charts.js"></script>
     <script src="docs/sync_diagnostics.js"></script>
+    <script src="js/hash_utils.js"></script>
     <script src="railway_client.js"></script>
 
     <!-- Sprite system -->

--- a/js/hash_utils.js
+++ b/js/hash_utils.js
@@ -1,0 +1,354 @@
+/*!
+ * Minimal MD5 implementation adapted from blueimp-md5 v2.19.0 (MIT License).
+ * https://github.com/blueimp/JavaScript-MD5
+ */
+(function (window) {
+  'use strict';
+
+  function safeAdd(x, y) {
+    const lsw = (x & 0xffff) + (y & 0xffff);
+    const msw = (x >> 16) + (y >> 16) + (lsw >> 16);
+    return (msw << 16) | (lsw & 0xffff);
+  }
+
+  function bitRotateLeft(num, cnt) {
+    return (num << cnt) | (num >>> (32 - cnt));
+  }
+
+  function md5cmn(q, a, b, x, s, t) {
+    return safeAdd(bitRotateLeft(safeAdd(safeAdd(a, q), safeAdd(x, t)), s), b);
+  }
+
+  function md5ff(a, b, c, d, x, s, t) {
+    return md5cmn((b & c) | (~b & d), a, b, x, s, t);
+  }
+
+  function md5gg(a, b, c, d, x, s, t) {
+    return md5cmn((b & d) | (c & ~d), a, b, x, s, t);
+  }
+
+  function md5hh(a, b, c, d, x, s, t) {
+    return md5cmn(b ^ c ^ d, a, b, x, s, t);
+  }
+
+  function md5ii(a, b, c, d, x, s, t) {
+    return md5cmn(c ^ (b | ~d), a, b, x, s, t);
+  }
+
+  function binlMD5(x, len) {
+    /* append padding */
+    x[len >> 5] |= 0x80 << (len % 32);
+    x[(((len + 64) >>> 9) << 4) + 14] = len;
+
+    let i;
+    let olda;
+    let oldb;
+    let oldc;
+    let oldd;
+    let a = 1732584193;
+    let b = -271733879;
+    let c = -1732584194;
+    let d = 271733878;
+
+    for (i = 0; i < x.length; i += 16) {
+      olda = a;
+      oldb = b;
+      oldc = c;
+      oldd = d;
+
+      a = md5ff(a, b, c, d, x[i], 7, -680876936);
+      d = md5ff(d, a, b, c, x[i + 1], 12, -389564586);
+      c = md5ff(c, d, a, b, x[i + 2], 17, 606105819);
+      b = md5ff(b, c, d, a, x[i + 3], 22, -1044525330);
+      a = md5ff(a, b, c, d, x[i + 4], 7, -176418897);
+      d = md5ff(d, a, b, c, x[i + 5], 12, 1200080426);
+      c = md5ff(c, d, a, b, x[i + 6], 17, -1473231341);
+      b = md5ff(b, c, d, a, x[i + 7], 22, -45705983);
+      a = md5ff(a, b, c, d, x[i + 8], 7, 1770035416);
+      d = md5ff(d, a, b, c, x[i + 9], 12, -1958414417);
+      c = md5ff(c, d, a, b, x[i + 10], 17, -42063);
+      b = md5ff(b, c, d, a, x[i + 11], 22, -1990404162);
+      a = md5ff(a, b, c, d, x[i + 12], 7, 1804603682);
+      d = md5ff(d, a, b, c, x[i + 13], 12, -40341101);
+      c = md5ff(c, d, a, b, x[i + 14], 17, -1502002290);
+      b = md5ff(b, c, d, a, x[i + 15], 22, 1236535329);
+
+      a = md5gg(a, b, c, d, x[i + 1], 5, -165796510);
+      d = md5gg(d, a, b, c, x[i + 6], 9, -1069501632);
+      c = md5gg(c, d, a, b, x[i + 11], 14, 643717713);
+      b = md5gg(b, c, d, a, x[i], 20, -373897302);
+      a = md5gg(a, b, c, d, x[i + 5], 5, -701558691);
+      d = md5gg(d, a, b, c, x[i + 10], 9, 38016083);
+      c = md5gg(c, d, a, b, x[i + 15], 14, -660478335);
+      b = md5gg(b, c, d, a, x[i + 4], 20, -405537848);
+      a = md5gg(a, b, c, d, x[i + 9], 5, 568446438);
+      d = md5gg(d, a, b, c, x[i + 14], 9, -1019803690);
+      c = md5gg(c, d, a, b, x[i + 3], 14, -187363961);
+      b = md5gg(b, c, d, a, x[i + 8], 20, 1163531501);
+      a = md5gg(a, b, c, d, x[i + 13], 5, -1444681467);
+      d = md5gg(d, a, b, c, x[i + 2], 9, -51403784);
+      c = md5gg(c, d, a, b, x[i + 7], 14, 1735328473);
+      b = md5gg(b, c, d, a, x[i + 12], 20, -1926607734);
+
+      a = md5hh(a, b, c, d, x[i + 5], 4, -378558);
+      d = md5hh(d, a, b, c, x[i + 8], 11, -2022574463);
+      c = md5hh(c, d, a, b, x[i + 11], 16, 1839030562);
+      b = md5hh(b, c, d, a, x[i + 14], 23, -35309556);
+      a = md5hh(a, b, c, d, x[i + 1], 4, -1530992060);
+      d = md5hh(d, a, b, c, x[i + 4], 11, 1272893353);
+      c = md5hh(c, d, a, b, x[i + 7], 16, -155497632);
+      b = md5hh(b, c, d, a, x[i + 10], 23, -1094730640);
+      a = md5hh(a, b, c, d, x[i + 13], 4, 681279174);
+      d = md5hh(d, a, b, c, x[i], 11, -358537222);
+      c = md5hh(c, d, a, b, x[i + 3], 16, -722521979);
+      b = md5hh(b, c, d, a, x[i + 6], 23, 76029189);
+      a = md5hh(a, b, c, d, x[i + 9], 4, -640364487);
+      d = md5hh(d, a, b, c, x[i + 12], 11, -421815835);
+      c = md5hh(c, d, a, b, x[i + 15], 16, 530742520);
+      b = md5hh(b, c, d, a, x[i + 2], 23, -995338651);
+
+      a = md5ii(a, b, c, d, x[i], 6, -198630844);
+      d = md5ii(d, a, b, c, x[i + 7], 10, 1126891415);
+      c = md5ii(c, d, a, b, x[i + 14], 15, -1416354905);
+      b = md5ii(b, c, d, a, x[i + 5], 21, -57434055);
+      a = md5ii(a, b, c, d, x[i + 12], 6, 1700485571);
+      d = md5ii(d, a, b, c, x[i + 3], 10, -1894986606);
+      c = md5ii(c, d, a, b, x[i + 10], 15, -1051523);
+      b = md5ii(b, c, d, a, x[i + 1], 21, -2054922799);
+      a = md5ii(a, b, c, d, x[i + 8], 6, 1873313359);
+      d = md5ii(d, a, b, c, x[i + 15], 10, -30611744);
+      c = md5ii(c, d, a, b, x[i + 6], 15, -1560198380);
+      b = md5ii(b, c, d, a, x[i + 13], 21, 1309151649);
+      a = md5ii(a, b, c, d, x[i + 4], 6, -145523070);
+      d = md5ii(d, a, b, c, x[i + 11], 10, -1120210379);
+      c = md5ii(c, d, a, b, x[i + 2], 15, 718787259);
+      b = md5ii(b, c, d, a, x[i + 9], 21, -343485551);
+
+      a = safeAdd(a, olda);
+      b = safeAdd(b, oldb);
+      c = safeAdd(c, oldc);
+      d = safeAdd(d, oldd);
+    }
+
+    return [a, b, c, d];
+  }
+
+  function binl2rstr(input) {
+    let i;
+    let output = '';
+    const length32 = input.length * 32;
+    for (i = 0; i < length32; i += 8) {
+      output += String.fromCharCode((input[i >> 5] >>> (i % 32)) & 0xff);
+    }
+    return output;
+  }
+
+  function rstr2binl(input) {
+    const output = [];
+    output[(input.length >> 2) - 1] = undefined;
+    for (let i = 0; i < output.length; i += 1) {
+      output[i] = 0;
+    }
+    const length8 = input.length * 8;
+    for (let i = 0; i < length8; i += 8) {
+      output[i >> 5] |= (input.charCodeAt(i / 8) & 0xff) << (i % 32);
+    }
+    return output;
+  }
+
+  function rstrMD5(s) {
+    return binl2rstr(binlMD5(rstr2binl(s), s.length * 8));
+  }
+
+  function rstr2hex(input) {
+    const hexTab = '0123456789abcdef';
+    let output = '';
+    let x;
+    for (let i = 0; i < input.length; i += 1) {
+      x = input.charCodeAt(i);
+      output += hexTab.charAt((x >>> 4) & 0x0f) + hexTab.charAt(x & 0x0f);
+    }
+    return output;
+  }
+
+  function str2rstrUTF8(input) {
+    return unescape(encodeURIComponent(input));
+  }
+
+  function rawMD5(s) {
+    return rstrMD5(str2rstrUTF8(s));
+  }
+
+  function md5(string) {
+    return rstr2hex(rawMD5(string));
+  }
+
+  function normalizeTimestamp(value) {
+    if (value === null || value === undefined) return 0;
+    if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value);
+    if (typeof value === 'string') {
+      const numeric = parseInt(value, 10);
+      if (!Number.isNaN(numeric)) return numeric;
+      const ms = Date.parse(value);
+      if (!Number.isNaN(ms)) return Math.trunc(ms);
+    }
+    return 0;
+  }
+
+  function parseUnitLesson(questionId) {
+    if (typeof questionId !== 'string') return null;
+    const match = questionId.match(/U(\d+)-L(\d+)/i);
+    if (!match) return null;
+    const unitNumber = parseInt(match[1], 10);
+    const lessonNumber = parseInt(match[2], 10);
+    return {
+      unitId: `unit${unitNumber}`,
+      lessonId: `U${unitNumber}-L${lessonNumber}`
+    };
+  }
+
+  function canonicalizeLessonAnswers(answers) {
+    const sorted = (answers || [])
+      .map((answer) => ({
+        username: (answer.username || '').trim(),
+        question_id: answer.question_id,
+        answer_value: answer.answer_value ?? null,
+        timestamp: normalizeTimestamp(answer.timestamp)
+      }))
+      .filter((answer) => answer.username && typeof answer.question_id === 'string')
+      .sort((a, b) => {
+        const userCompare = a.username.localeCompare(b.username);
+        if (userCompare !== 0) return userCompare;
+        const questionCompare = a.question_id.localeCompare(b.question_id);
+        if (questionCompare !== 0) return questionCompare;
+        return a.timestamp - b.timestamp;
+      });
+
+    return JSON.stringify(sorted);
+  }
+
+  function computeLessonHash(answers) {
+    return md5(canonicalizeLessonAnswers(answers));
+  }
+
+  function computeUnitHashFromLessons(lessons) {
+    const entries = Object.keys(lessons)
+      .sort((a, b) => a.localeCompare(b))
+      .map((lessonId) => ({ lessonId, hash: lessons[lessonId].hash }));
+    return md5(JSON.stringify(entries));
+  }
+
+  function gatherAllLocalAnswers() {
+    const deduped = new Map();
+
+    function addAnswer(username, questionId, value, timestamp) {
+      if (!username || !questionId) return;
+      const key = `${username.trim()}::${questionId}`;
+      const normalized = {
+        username: username.trim(),
+        question_id: questionId,
+        answer_value: value ?? null,
+        timestamp: normalizeTimestamp(timestamp)
+      };
+      const existing = deduped.get(key);
+      if (!existing || normalized.timestamp >= existing.timestamp) {
+        deduped.set(key, normalized);
+      }
+    }
+
+    const classData = window.classData;
+    if (classData && classData.users) {
+      Object.entries(classData.users).forEach(([username, data]) => {
+        const answers = data?.answers || {};
+        Object.entries(answers).forEach(([questionId, info]) => {
+          const answerValue = info?.value ?? info;
+          const timestamp = data?.timestamps?.[questionId] ?? info?.timestamp ?? 0;
+          addAnswer(username, questionId, answerValue, timestamp);
+        });
+      });
+    }
+
+    Object.keys(localStorage)
+      .filter((key) => key.startsWith('answers_'))
+      .forEach((key) => {
+        try {
+          const username = key.replace('answers_', '');
+          const stored = JSON.parse(localStorage.getItem(key) || '{}');
+          Object.entries(stored).forEach(([questionId, info]) => {
+            const answerValue = info?.value ?? info;
+            const timestamp = info?.timestamp ?? 0;
+            addAnswer(username, questionId, answerValue, timestamp);
+          });
+        } catch (error) {
+          console.warn('Failed to parse localStorage answers for key', key, error);
+        }
+      });
+
+    return Array.from(deduped.values());
+  }
+
+  function buildLocalSyncIndex() {
+    const answers = gatherAllLocalAnswers();
+    const unitBuckets = new Map();
+
+    answers.forEach((answer) => {
+      const mapping = parseUnitLesson(answer.question_id);
+      if (!mapping) return;
+
+      let lessonBuckets = unitBuckets.get(mapping.unitId);
+      if (!lessonBuckets) {
+        lessonBuckets = new Map();
+        unitBuckets.set(mapping.unitId, lessonBuckets);
+      }
+
+      let lessonMap = lessonBuckets.get(mapping.lessonId);
+      if (!lessonMap) {
+        lessonMap = new Map();
+        lessonBuckets.set(mapping.lessonId, lessonMap);
+      }
+
+      const key = `${answer.username}::${answer.question_id}`;
+      const existing = lessonMap.get(key);
+      if (!existing || answer.timestamp >= existing.timestamp) {
+        lessonMap.set(key, answer);
+      }
+    });
+
+    const units = {};
+
+    unitBuckets.forEach((lessonBuckets, unitId) => {
+      const lessons = {};
+      lessonBuckets.forEach((answerMap, lessonId) => {
+        const answersArray = Array.from(answerMap.values()).sort((a, b) => {
+          const userCompare = a.username.localeCompare(b.username);
+          if (userCompare !== 0) return userCompare;
+          const questionCompare = a.question_id.localeCompare(b.question_id);
+          if (questionCompare !== 0) return questionCompare;
+          return a.timestamp - b.timestamp;
+        });
+        lessons[lessonId] = {
+          hash: computeLessonHash(answersArray),
+          answers: answersArray,
+          answerCount: answersArray.length
+        };
+      });
+      units[unitId] = {
+        hash: computeUnitHashFromLessons(lessons),
+        lessons
+      };
+    });
+
+    return { units };
+  }
+
+  window.HashUtils = {
+    md5,
+    normalizeTimestamp,
+    parseUnitLesson,
+    canonicalizeLessonAnswers,
+    computeLessonHash,
+    computeUnitHashFromLessons,
+    buildLocalSyncIndex,
+    gatherAllLocalAnswers
+  };
+})(window);

--- a/railway-server/package.json
+++ b/railway-server/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "description": "Railway server for AP Stats Consensus Quiz - handles Supabase sync and WebSocket connections",
   "main": "server.js",
-  "type": "module",
   "scripts": {
     "start": "node server.js",
-    "dev": "node --watch server.js"
+    "dev": "node --watch server.js",
+    "test": "node test.js"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/railway-server/server.js
+++ b/railway-server/server.js
@@ -1,11 +1,18 @@
 // Simple Railway server for AP Stats Turbo Mode
 // No build step required - just plain Node.js
 
-import express from 'express';
-import cors from 'cors';
-import { WebSocketServer } from 'ws';
-import { createClient } from '@supabase/supabase-js';
-import dotenv from 'dotenv';
+const express = require('express');
+const cors = require('cors');
+const { WebSocketServer } = require('ws');
+const { createClient } = require('@supabase/supabase-js');
+const dotenv = require('dotenv');
+
+const {
+  buildSyncIndexFromAnswers,
+  normalizeTimestamp,
+  parseUnitLesson,
+  computeUnitHash
+} = require('./sync_utils');
 
 // Load environment variables
 dotenv.config();
@@ -31,6 +38,13 @@ const cache = {
   TTL: 30000 // 30 seconds cache
 };
 
+const syncCache = {
+  units: new Map(),
+  lessonToUnit: new Map(),
+  lastBuilt: 0,
+  ttl: 60000
+};
+
 // Track connected WebSocket clients
 const wsClients = new Set();
 
@@ -44,12 +58,135 @@ function isCacheValid(lastUpdate, ttl = cache.TTL) {
   return Date.now() - lastUpdate < ttl;
 }
 
-// Convert timestamps to numbers if they're strings
-function normalizeTimestamp(timestamp) {
-  if (typeof timestamp === 'string') {
-    return new Date(timestamp).getTime();
+function getUnitIdFromLessonId(lessonId) {
+  if (typeof lessonId !== 'string') return null;
+  const match = lessonId.match(/U(\d+)-L/i);
+  if (!match) return null;
+  return `unit${parseInt(match[1], 10)}`;
+}
+
+async function rebuildFullSyncCache() {
+  const { data, error } = await supabase
+    .from('answers')
+    .select('*');
+
+  if (error) throw error;
+
+  const normalizedData = (data || []).map((answer) => ({
+    ...answer,
+    timestamp: normalizeTimestamp(answer.timestamp)
+  }));
+
+  cache.peerData = normalizedData;
+  cache.lastUpdate = Date.now();
+
+  const { units } = buildSyncIndexFromAnswers(normalizedData);
+  syncCache.units = units;
+  syncCache.lessonToUnit = new Map();
+  units.forEach((unitData, unitId) => {
+    if (unitData?.lessons) {
+      unitData.lessons.forEach((_, lessonId) => {
+        syncCache.lessonToUnit.set(lessonId, unitId);
+      });
+    }
+  });
+  syncCache.lastBuilt = Date.now();
+}
+
+function isSyncCacheFresh() {
+  return syncCache.units.size > 0 && (Date.now() - syncCache.lastBuilt) < syncCache.ttl;
+}
+
+async function ensureSyncCache(force = false) {
+  if (!force && isSyncCacheFresh()) {
+    return;
   }
-  return timestamp;
+  await rebuildFullSyncCache();
+}
+
+function updateLessonMappingsForUnit(unitId, unitData) {
+  const activeLessons = new Set();
+  if (unitData?.lessons) {
+    unitData.lessons.forEach((_, lessonId) => {
+      activeLessons.add(lessonId);
+      syncCache.lessonToUnit.set(lessonId, unitId);
+    });
+  }
+
+  Array.from(syncCache.lessonToUnit.entries()).forEach(([lessonId, mappedUnit]) => {
+    if (mappedUnit === unitId && !activeLessons.has(lessonId)) {
+      syncCache.lessonToUnit.delete(lessonId);
+    }
+  });
+}
+
+async function refreshUnitCache(unitId) {
+  if (!unitId) return null;
+  const match = unitId.match(/unit(\d+)/i);
+  if (!match) return null;
+  const unitNumber = parseInt(match[1], 10);
+  const prefix = `U${unitNumber}-`;
+
+  const { data, error } = await supabase
+    .from('answers')
+    .select('*')
+    .ilike('question_id', `${prefix}%`);
+
+  if (error) throw error;
+
+  const normalized = (data || []).map((answer) => ({
+    ...answer,
+    timestamp: normalizeTimestamp(answer.timestamp)
+  }));
+
+  const { units } = buildSyncIndexFromAnswers(normalized);
+  const unitData = units.get(unitId) || {
+    hash: computeUnitHash(new Map()),
+    lessons: new Map(),
+    lastUpdated: Date.now()
+  };
+
+  syncCache.units.set(unitId, unitData);
+  updateLessonMappingsForUnit(unitId, unitData);
+  syncCache.lastBuilt = Date.now();
+
+  return unitData;
+}
+
+async function refreshUnitCacheByQuestion(questionId) {
+  const mapping = parseUnitLesson(questionId);
+  if (!mapping) return null;
+  const unitData = await refreshUnitCache(mapping.unitId);
+  const lessonData = unitData?.lessons?.get(mapping.lessonId) || null;
+  return {
+    unitId: mapping.unitId,
+    lessonId: mapping.lessonId,
+    unitHash: unitData?.hash || null,
+    lessonHash: lessonData?.hash || null,
+    lessonAnswerCount: lessonData?.answerCount || 0
+  };
+}
+
+async function ensureLessonCache(lessonId) {
+  if (!lessonId) return null;
+  let unitId = syncCache.lessonToUnit.get(lessonId);
+  if (!unitId) {
+    unitId = getUnitIdFromLessonId(lessonId);
+  }
+  if (!unitId) return null;
+
+  let unitData = syncCache.units.get(unitId);
+  if (!unitData || !unitData.lessons?.has(lessonId)) {
+    unitData = await refreshUnitCache(unitId);
+  }
+
+  if (!unitData) return null;
+  const lessonData = unitData.lessons?.get(lessonId);
+  if (!lessonData) {
+    return null;
+  }
+
+  return { unitId, unitData, lessonData };
 }
 
 // ============================
@@ -191,6 +328,91 @@ app.get('/api/question-stats/:questionId', async (req, res) => {
   }
 });
 
+app.get('/api/sync/manifest', async (req, res) => {
+  try {
+    await ensureSyncCache();
+
+    const units = {};
+    syncCache.units.forEach((unitData, unitId) => {
+      units[unitId] = {
+        hash: unitData.hash,
+        lessonCount: unitData.lessons?.size || 0,
+        updatedAt: unitData.lastUpdated || syncCache.lastBuilt
+      };
+    });
+
+    res.json({
+      generatedAt: Date.now(),
+      unitCount: Object.keys(units).length,
+      units
+    });
+  } catch (error) {
+    console.error('Error building sync manifest:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+app.get('/api/sync/unit/:unitId', async (req, res) => {
+  try {
+    const { unitId } = req.params;
+    await ensureSyncCache();
+
+    let unitData = syncCache.units.get(unitId);
+    if (!unitData) {
+      unitData = await refreshUnitCache(unitId);
+    }
+
+    if (!unitData) {
+      return res.status(404).json({ error: 'Unit not found' });
+    }
+
+    const lessons = {};
+    unitData.lessons?.forEach((lessonData, lessonId) => {
+      lessons[lessonId] = {
+        hash: lessonData.hash,
+        answerCount: lessonData.answerCount || (lessonData.answers?.length || 0),
+        updatedAt: lessonData.lastUpdated || unitData.lastUpdated || syncCache.lastBuilt
+      };
+    });
+
+    res.json({
+      unitId,
+      hash: unitData.hash,
+      lessons,
+      lessonCount: Object.keys(lessons).length,
+      updatedAt: unitData.lastUpdated || syncCache.lastBuilt
+    });
+  } catch (error) {
+    console.error('Error fetching unit manifest:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+app.get('/api/data/lesson/:lessonId', async (req, res) => {
+  try {
+    const { lessonId } = req.params;
+    const lessonInfo = await ensureLessonCache(lessonId);
+
+    if (!lessonInfo) {
+      return res.status(404).json({ error: 'Lesson not found' });
+    }
+
+    const { unitId, lessonData } = lessonInfo;
+
+    res.json({
+      unitId,
+      lessonId,
+      hash: lessonData.hash,
+      answers: lessonData.answers || [],
+      answerCount: lessonData.answerCount || (lessonData.answers?.length || 0),
+      updatedAt: lessonData.lastUpdated || syncCache.lastBuilt
+    });
+  } catch (error) {
+    console.error('Error fetching lesson data:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
 // Submit answer (proxies to Supabase and broadcasts via WebSocket)
 app.post('/api/submit-answer', async (req, res) => {
   try {
@@ -215,13 +437,20 @@ app.post('/api/submit-answer', async (req, res) => {
     cache.lastUpdate = 0;
     cache.questionStats.delete(question_id);
 
+    const manifestUpdate = await refreshUnitCacheByQuestion(question_id);
+
     // Broadcast to WebSocket clients
     const update = {
       type: 'answer_submitted',
       username,
       question_id,
       answer_value,
-      timestamp: normalizedTimestamp
+      timestamp: normalizedTimestamp,
+      unitId: manifestUpdate?.unitId || null,
+      lessonId: manifestUpdate?.lessonId || null,
+      unitHash: manifestUpdate?.unitHash || null,
+      lessonHash: manifestUpdate?.lessonHash || null,
+      lessonAnswerCount: manifestUpdate?.lessonAnswerCount || 0
     };
 
     broadcastToClients(update);
@@ -229,7 +458,8 @@ app.post('/api/submit-answer', async (req, res) => {
     res.json({
       success: true,
       timestamp: normalizedTimestamp,
-      broadcast: wsClients.size
+      broadcast: wsClients.size,
+      manifest: manifestUpdate
     });
 
   } catch (error) {
@@ -264,11 +494,38 @@ app.post('/api/batch-submit', async (req, res) => {
     cache.lastUpdate = 0;
     cache.questionStats.clear();
 
+    const affectedUnits = new Set();
+    normalizedAnswers.forEach((answer) => {
+      const mapping = parseUnitLesson(answer.question_id);
+      if (mapping) {
+        affectedUnits.add(mapping.unitId);
+      }
+    });
+
+    const manifestUpdates = [];
+    for (const unitId of affectedUnits) {
+      const unitData = await refreshUnitCache(unitId);
+      const lessons = [];
+      unitData?.lessons?.forEach((lessonData, lessonId) => {
+        lessons.push({
+          lessonId,
+          hash: lessonData.hash,
+          answerCount: lessonData.answerCount || (lessonData.answers?.length || 0)
+        });
+      });
+      manifestUpdates.push({
+        unitId,
+        unitHash: unitData?.hash || null,
+        lessons
+      });
+    }
+
     // Broadcast batch update
     const update = {
       type: 'batch_submitted',
       count: normalizedAnswers.length,
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      units: manifestUpdates
     };
 
     broadcastToClients(update);
@@ -276,7 +533,8 @@ app.post('/api/batch-submit', async (req, res) => {
     res.json({
       success: true,
       count: normalizedAnswers.length,
-      broadcast: wsClients.size
+      broadcast: wsClients.size,
+      units: manifestUpdates
     });
 
   } catch (error) {
@@ -326,6 +584,10 @@ const server = app.listen(PORT, () => {
 });
 
 const wss = new WebSocketServer({ server });
+
+ensureSyncCache(true).catch((error) => {
+  console.error('Initial sync cache warmup failed:', error);
+});
 
 wss.on('connection', (ws) => {
   console.log('New WebSocket client connected');
@@ -468,6 +730,13 @@ const subscription = supabase
 
       // Invalidate cache
       cache.lastUpdate = 0;
+
+      const questionId = payload.new?.question_id || payload.old?.question_id;
+      if (questionId) {
+        refreshUnitCacheByQuestion(questionId).catch((error) => {
+          console.error('Failed to refresh unit cache from realtime update:', error);
+        });
+      }
 
       // Broadcast to all WebSocket clients
       broadcastToClients({

--- a/railway-server/sync_utils.js
+++ b/railway-server/sync_utils.js
@@ -1,0 +1,142 @@
+const crypto = require('crypto');
+
+function normalizeTimestamp(value) {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  if (typeof value === 'string') {
+    const numeric = parseInt(value, 10);
+    if (!Number.isNaN(numeric)) {
+      return numeric;
+    }
+    const ms = Date.parse(value);
+    if (!Number.isNaN(ms)) {
+      return Math.trunc(ms);
+    }
+  }
+  return 0;
+}
+
+function parseUnitLesson(questionId) {
+  if (typeof questionId !== 'string') return null;
+  const match = questionId.match(/U(\d+)-L(\d+)/i);
+  if (!match) return null;
+  const unitNumber = match[1];
+  const lessonNumber = match[2];
+  const unitId = `unit${parseInt(unitNumber, 10)}`;
+  const lessonId = `U${parseInt(unitNumber, 10)}-L${parseInt(lessonNumber, 10)}`;
+  return { unitId, lessonId };
+}
+
+function canonicalizeLessonAnswers(answers) {
+  const sorted = (answers || [])
+    .map((answer) => ({
+      username: (answer.username || '').trim(),
+      question_id: answer.question_id,
+      answer_value: answer.answer_value ?? null,
+      timestamp: normalizeTimestamp(answer.timestamp)
+    }))
+    .filter((answer) => answer.username && typeof answer.question_id === 'string')
+    .sort((a, b) => {
+      const userCompare = a.username.localeCompare(b.username);
+      if (userCompare !== 0) return userCompare;
+      const questionCompare = a.question_id.localeCompare(b.question_id);
+      if (questionCompare !== 0) return questionCompare;
+      return a.timestamp - b.timestamp;
+    });
+  return JSON.stringify(sorted);
+}
+
+function hashString(value) {
+  return crypto.createHash('md5').update(value).digest('hex');
+}
+
+function computeLessonHash(answers) {
+  return hashString(canonicalizeLessonAnswers(answers));
+}
+
+function computeUnitHash(lessonsMap) {
+  const entries = Array.from(lessonsMap.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([lessonId, lessonData]) => ({ lessonId, hash: lessonData.hash }));
+  return hashString(JSON.stringify(entries));
+}
+
+function buildSyncIndexFromAnswers(rawAnswers) {
+  const unitBuckets = new Map();
+
+  (rawAnswers || []).forEach((raw) => {
+    const bucketInfo = parseUnitLesson(raw.question_id);
+    if (!bucketInfo) return;
+
+    const normalized = {
+      username: (raw.username || '').trim(),
+      question_id: raw.question_id,
+      answer_value: raw.answer_value ?? null,
+      timestamp: normalizeTimestamp(raw.timestamp)
+    };
+
+    if (!normalized.username) return;
+
+    let lessonBuckets = unitBuckets.get(bucketInfo.unitId);
+    if (!lessonBuckets) {
+      lessonBuckets = new Map();
+      unitBuckets.set(bucketInfo.unitId, lessonBuckets);
+    }
+
+    let lessonMap = lessonBuckets.get(bucketInfo.lessonId);
+    if (!lessonMap) {
+      lessonMap = new Map();
+      lessonBuckets.set(bucketInfo.lessonId, lessonMap);
+    }
+
+    const key = `${normalized.username}::${normalized.question_id}`;
+    const existing = lessonMap.get(key);
+    if (!existing || normalized.timestamp >= existing.timestamp) {
+      lessonMap.set(key, normalized);
+    }
+  });
+
+  const units = new Map();
+
+  unitBuckets.forEach((lessonBuckets, unitId) => {
+    const lessons = new Map();
+
+    lessonBuckets.forEach((answerMap, lessonId) => {
+      const answers = Array.from(answerMap.values()).sort((a, b) => {
+        const userCompare = a.username.localeCompare(b.username);
+        if (userCompare !== 0) return userCompare;
+        const questionCompare = a.question_id.localeCompare(b.question_id);
+        if (questionCompare !== 0) return questionCompare;
+        return a.timestamp - b.timestamp;
+      });
+
+      const hash = computeLessonHash(answers);
+      lessons.set(lessonId, {
+        hash,
+        answers,
+        answerCount: answers.length,
+        lastUpdated: Date.now()
+      });
+    });
+
+    const unitHash = computeUnitHash(lessons);
+    units.set(unitId, {
+      hash: unitHash,
+      lessons,
+      lastUpdated: Date.now()
+    });
+  });
+
+  return { units };
+}
+
+module.exports = {
+  buildSyncIndexFromAnswers,
+  canonicalizeLessonAnswers,
+  computeLessonHash,
+  computeUnitHash,
+  normalizeTimestamp,
+  parseUnitLesson
+};

--- a/railway-server/test.js
+++ b/railway-server/test.js
@@ -1,0 +1,71 @@
+const assert = require('assert');
+const {
+  buildSyncIndexFromAnswers,
+  canonicalizeLessonAnswers,
+  computeLessonHash,
+  computeUnitHash,
+  normalizeTimestamp,
+  parseUnitLesson
+} = require('./sync_utils');
+
+function testParseUnitLesson() {
+  const parsed = parseUnitLesson('U3-L7-Q09');
+  assert.deepStrictEqual(parsed, { unitId: 'unit3', lessonId: 'U3-L7' });
+  assert.strictEqual(parseUnitLesson('invalid'), null);
+}
+
+function testNormalizeTimestamp() {
+  assert.strictEqual(normalizeTimestamp(1234), 1234);
+  assert.strictEqual(normalizeTimestamp('5678'), 5678);
+  const approx = normalizeTimestamp('2024-01-01T00:00:00Z');
+  assert.ok(approx > 0, 'ISO timestamp should parse to milliseconds');
+}
+
+function testBuildSyncIndex() {
+  const rawAnswers = [
+    { username: 'alice', question_id: 'U1-L2-Q01', answer_value: 'A', timestamp: 1000 },
+    { username: 'bob', question_id: 'U1-L2-Q02', answer_value: 'B', timestamp: '2000' },
+    { username: 'alice', question_id: 'U1-L3-Q01', answer_value: 'C', timestamp: '2024-01-01T00:00:00Z' },
+    { username: 'alice', question_id: 'U2-L1-Q01', answer_value: 'D', timestamp: 3000 },
+    { username: 'alice', question_id: 'U1-L2-Q01', answer_value: 'A+', timestamp: 1500 } // newer duplicate
+  ];
+
+  const { units } = buildSyncIndexFromAnswers(rawAnswers);
+  assert.strictEqual(units.size, 2, 'Should have two units');
+
+  const unit1 = units.get('unit1');
+  assert.ok(unit1, 'unit1 should exist');
+  assert.strictEqual(unit1.lessons.size, 2, 'unit1 should have two lessons');
+
+  const lessonL2 = unit1.lessons.get('U1-L2');
+  assert.ok(lessonL2, 'Lesson U1-L2 should be tracked');
+  assert.strictEqual(lessonL2.answerCount, 2, 'Lesson should dedupe to two answers');
+  const aliceAnswer = lessonL2.answers.find((a) => a.username === 'alice' && a.question_id === 'U1-L2-Q01');
+  assert.ok(aliceAnswer, 'Alice answer should exist');
+  assert.strictEqual(aliceAnswer.answer_value, 'A+', 'Newer duplicate should win');
+
+  const lessonHashes = canonicalizeLessonAnswers(lessonL2.answers);
+  assert.strictEqual(typeof lessonHashes, 'string', 'Canonical form should be a string');
+  assert.strictEqual(computeLessonHash(lessonL2.answers), computeLessonHash(lessonL2.answers), 'Lesson hash should be stable');
+
+  const expectedUnitHash = computeUnitHash(unit1.lessons);
+  assert.strictEqual(unit1.hash, expectedUnitHash, 'Unit hash should reflect lesson hashes');
+}
+
+function run() {
+  testParseUnitLesson();
+  testNormalizeTimestamp();
+  testBuildSyncIndex();
+  console.log('All sync utility tests passed.');
+}
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = {
+  run,
+  testParseUnitLesson,
+  testNormalizeTimestamp,
+  testBuildSyncIndex
+};

--- a/railway_client.js
+++ b/railway_client.js
@@ -5,6 +5,331 @@
   const RAILWAY_SERVER_URL = window.RAILWAY_SERVER_URL || 'https://your-app.up.railway.app';
   const USE_RAILWAY = window.USE_RAILWAY || false;
 
+  const HashUtils = window.HashUtils || {};
+  const manifestStorageKey = 'railway_manifest_cache_v1';
+
+  let lastSyncSummary = null;
+
+  function safeJsonParse(value, fallback = null) {
+      try {
+          return value ? JSON.parse(value) : fallback;
+      } catch (error) {
+          console.warn('Failed to parse JSON payload from storage', error);
+          return fallback;
+      }
+  }
+
+  function loadStoredManifest() {
+      return safeJsonParse(localStorage.getItem(manifestStorageKey), { units: {} });
+  }
+
+  function saveStoredManifest(manifest) {
+      try {
+          localStorage.setItem(manifestStorageKey, JSON.stringify(manifest));
+      } catch (error) {
+          console.warn('Unable to store manifest cache', error);
+      }
+  }
+
+  function updateStoredManifestUnit(unitId, unitInfo = {}) {
+      const manifest = loadStoredManifest();
+      manifest.units = manifest.units || {};
+      manifest.units[unitId] = {
+          ...(manifest.units[unitId] || {}),
+          ...unitInfo,
+          lessons: {
+              ...(manifest.units[unitId]?.lessons || {}),
+              ...(unitInfo.lessons || {})
+          }
+      };
+      saveStoredManifest(manifest);
+  }
+
+  function updateStoredManifestLesson(unitId, lessonId, lessonInfo = {}) {
+      const manifest = loadStoredManifest();
+      manifest.units = manifest.units || {};
+      manifest.units[unitId] = manifest.units[unitId] || { lessons: {} };
+      manifest.units[unitId].lessons = manifest.units[unitId].lessons || {};
+      manifest.units[unitId].lessons[lessonId] = {
+          ...(manifest.units[unitId].lessons[lessonId] || {}),
+          ...lessonInfo
+      };
+      saveStoredManifest(manifest);
+  }
+
+  async function fetchJson(url, options = {}) {
+      const response = await fetch(url, options);
+      if (!response.ok) {
+          const text = await response.text();
+          throw new Error(`Request failed (${response.status}): ${text}`);
+      }
+      return response.json();
+  }
+
+  function computeLocalSyncIndex() {
+      if (HashUtils && typeof HashUtils.buildLocalSyncIndex === 'function') {
+          return HashUtils.buildLocalSyncIndex();
+      }
+      return { units: {} };
+  }
+
+  function buildPeerDataSnapshot() {
+      const answers = HashUtils && typeof HashUtils.gatherAllLocalAnswers === 'function'
+          ? HashUtils.gatherAllLocalAnswers()
+          : [];
+
+      const peerData = {};
+      answers.forEach((answer) => {
+          if (!peerData[answer.username]) {
+              peerData[answer.username] = { answers: {} };
+          }
+          peerData[answer.username].answers[answer.question_id] = {
+              value: answer.answer_value,
+              timestamp: answer.timestamp
+          };
+      });
+
+      return peerData;
+  }
+
+  function normalizeDetail(detail) {
+      return {
+          username: (detail.username || '').trim(),
+          question_id: detail.question_id,
+          answer_value: detail.answer_value,
+          timestamp: HashUtils && typeof HashUtils.normalizeTimestamp === 'function'
+              ? HashUtils.normalizeTimestamp(detail.timestamp)
+              : parseInt(detail.timestamp, 10) || Date.now()
+      };
+  }
+
+  function applyLessonAnswer(detail) {
+      const normalized = normalizeDetail(detail);
+      if (!normalized.username || !normalized.question_id) return false;
+
+      if (typeof window.ensureClassDataInitialized === 'function') {
+          window.ensureClassDataInitialized();
+      }
+
+      if (typeof window.mergePeerAnswer !== 'function') {
+          console.warn('mergePeerAnswer is not available - skipping local merge');
+          return false;
+      }
+
+      const updated = window.mergePeerAnswer(normalized);
+      if (!updated) {
+          return false;
+      }
+
+      try {
+          if (window.spriteManager && typeof window.checkIfAnswerCorrect === 'function') {
+              const isCorrect = window.checkIfAnswerCorrect(normalized.question_id, normalized.answer_value);
+              window.spriteManager.handlePeerAnswer(normalized.username, isCorrect);
+          }
+      } catch (error) {
+          console.warn('Sprite update failed after lesson sync', error);
+      }
+
+      if (typeof requestAnimationFrame === 'function') {
+          requestAnimationFrame(() => {
+              try {
+                  if (typeof window.refreshQuestionIfVisible === 'function') {
+                      window.refreshQuestionIfVisible(normalized.question_id);
+                  }
+                  if (typeof window.updatePeerDataTimestamp === 'function') {
+                      window.updatePeerDataTimestamp();
+                  }
+              } catch (error) {
+                  console.warn('UI refresh failed after lesson sync', error);
+              }
+          });
+      }
+
+      return true;
+  }
+
+  function ingestLessonAnswers(lessonId, answers = []) {
+      let applied = 0;
+      answers.forEach((answer) => {
+          const detail = {
+              username: answer.username,
+              question_id: answer.question_id,
+              answer_value: answer.answer_value,
+              timestamp: answer.timestamp
+          };
+          if (applyLessonAnswer(detail)) {
+              applied += 1;
+          }
+      });
+      return applied;
+  }
+
+  function clearLocalLessonData(lessonId) {
+      if (!lessonId) return 0;
+      if (typeof window.ensureClassDataInitialized === 'function') {
+          window.ensureClassDataInitialized();
+      }
+
+      let removed = 0;
+      const prefix = `${lessonId}-`;
+
+      if (window.classData && window.classData.users) {
+          Object.entries(window.classData.users).forEach(([username, data]) => {
+              const answers = data.answers || {};
+              const timestamps = data.timestamps || {};
+              Object.keys(answers).forEach((questionId) => {
+                  if (questionId.startsWith(prefix)) {
+                      delete answers[questionId];
+                      delete timestamps[questionId];
+                      removed += 1;
+                  }
+              });
+          });
+          if (removed > 0 && typeof window.saveClassData === 'function') {
+              window.saveClassData();
+          }
+      }
+
+      Object.keys(localStorage)
+          .filter((key) => key.startsWith('answers_'))
+          .forEach((key) => {
+              const stored = safeJsonParse(localStorage.getItem(key), {});
+              let modified = false;
+              Object.keys(stored).forEach((questionId) => {
+                  if (questionId.startsWith(prefix)) {
+                      delete stored[questionId];
+                      modified = true;
+                  }
+              });
+              if (modified) {
+                  localStorage.setItem(key, JSON.stringify(stored));
+              }
+          });
+
+      return removed;
+  }
+
+  async function performMerkleSync() {
+      if (!USE_RAILWAY) return null;
+
+      try {
+          const manifest = await fetchJson(`${RAILWAY_SERVER_URL}/api/sync/manifest`);
+          saveStoredManifest({
+              generatedAt: manifest.generatedAt,
+              units: manifest.units || {}
+          });
+
+          const serverUnits = manifest.units || {};
+          const localIndex = computeLocalSyncIndex();
+          const localUnits = localIndex.units || {};
+
+          const unitsNeedingDetail = [];
+          Object.keys(serverUnits).forEach((unitId) => {
+              const serverUnit = serverUnits[unitId];
+              const localUnit = localUnits[unitId];
+              if (!localUnit || localUnit.hash !== serverUnit.hash) {
+                  unitsNeedingDetail.push(unitId);
+              }
+          });
+
+          // Remove local units that no longer exist on the server
+          Object.keys(localUnits).forEach((unitId) => {
+              if (!serverUnits[unitId]) {
+                  const lessons = localUnits[unitId]?.lessons || {};
+                  Object.keys(lessons).forEach((lessonId) => {
+                      clearLocalLessonData(lessonId);
+                  });
+              }
+          });
+
+          let lessonsFetched = 0;
+          let answersApplied = 0;
+
+          for (const unitId of unitsNeedingDetail) {
+              const unitManifest = await fetchJson(`${RAILWAY_SERVER_URL}/api/sync/unit/${unitId}`);
+              const serverLessons = unitManifest.lessons || {};
+              const localLessons = localUnits[unitId]?.lessons || {};
+
+              // Remove lessons that no longer exist on the server
+              Object.keys(localLessons).forEach((lessonId) => {
+                  if (!serverLessons[lessonId]) {
+                      clearLocalLessonData(lessonId);
+                  }
+              });
+
+              updateStoredManifestUnit(unitId, {
+                  hash: unitManifest.hash,
+                  lessonCount: unitManifest.lessonCount,
+                  lessons: serverLessons
+              });
+
+              for (const [lessonId, lessonInfo] of Object.entries(serverLessons)) {
+                  const localLesson = localLessons[lessonId];
+                  if (localLesson && localLesson.hash === lessonInfo.hash) {
+                      continue; // already in sync
+                  }
+
+                  const lessonPayload = await fetchJson(`${RAILWAY_SERVER_URL}/api/data/lesson/${lessonId}`);
+                  lessonsFetched += 1;
+                  const applied = ingestLessonAnswers(lessonId, lessonPayload.answers || []);
+                  answersApplied += applied;
+
+                  updateStoredManifestLesson(unitId, lessonId, {
+                      hash: lessonPayload.hash,
+                      answerCount: lessonPayload.answerCount,
+                      updatedAt: lessonPayload.updatedAt
+                  });
+              }
+          }
+
+          lastSyncSummary = {
+              generatedAt: manifest.generatedAt,
+              unitCount: Object.keys(serverUnits).length,
+              unitsUpdated: unitsNeedingDetail.length,
+              lessonsFetched,
+              answersApplied
+          };
+
+          if (lessonsFetched === 0) {
+              console.log('✅ Merkle sync: local data already matches server manifest.');
+          } else {
+              console.log(`✅ Merkle sync: updated ${lessonsFetched} lessons with ${answersApplied} answers.`);
+          }
+
+          return lastSyncSummary;
+      } catch (error) {
+          console.error('Merkle sync failed:', error);
+          throw error;
+      }
+  }
+
+  function updateBroadcastManifest(data) {
+      if (!data || !data.unitId) return;
+      const lessons = {};
+      if (Array.isArray(data.lessons)) {
+          data.lessons.forEach((lesson) => {
+              if (lesson?.lessonId) {
+                  lessons[lesson.lessonId] = {
+                      hash: lesson.hash,
+                      answerCount: lesson.answerCount,
+                      updatedAt: Date.now()
+                  };
+              }
+          });
+      } else if (data.lessonId) {
+          lessons[data.lessonId] = {
+              hash: data.lessonHash,
+              answerCount: data.lessonAnswerCount,
+              updatedAt: Date.now()
+          };
+      }
+
+      updateStoredManifestUnit(data.unitId, {
+          hash: data.unitHash,
+          lessons
+      });
+  }
+
   // WebSocket connection
   let ws = null;
   let wsReconnectTimer = null;
@@ -26,6 +351,9 @@
           .then(data => {
               console.log('✅ Railway server connected:', data);
               connectWebSocket();
+              performMerkleSync().catch(error => {
+                  console.warn('Initial Merkle sync failed after health check:', error);
+              });
           })
           .catch(error => {
               console.error('❌ Railway server unavailable:', error);
@@ -167,6 +495,7 @@
                   console.error('[WebSocket] Invalid or incomplete answer_submitted data received:', data);
                   break;
               }
+              updateBroadcastManifest(data);
               console.log(`📨 Received answer for ${data.question_id}, dispatching 'peer:answer' event.`);
               window.dispatchEvent(new CustomEvent('peer:answer', {
                   detail: {
@@ -180,6 +509,9 @@
 
           case 'batch_submitted':
               console.log(`📦 Batch update: ${data.count} answers`);
+              if (Array.isArray(data.units)) {
+                  data.units.forEach((unit) => updateBroadcastManifest(unit));
+              }
               // Pull latest data from server
               pullPeerDataFromRailway();
               break;
@@ -235,57 +567,21 @@
   }
 
   // Pull peer data from Railway server
-  async function pullPeerDataFromRailway(since = 0) {
+  async function pullPeerDataFromRailway() {
       if (!USE_RAILWAY) {
           // Fall back to direct Supabase
           return pullPeerDataFromSupabase();
       }
 
       try {
-          const url = since > 0
-              ? `${RAILWAY_SERVER_URL}/api/peer-data?since=${since}`
-              : `${RAILWAY_SERVER_URL}/api/peer-data`;
-
-          const response = await fetch(url);
-          const result = await response.json();
-
-          console.log(`📥 Pulled ${result.filtered} answers from Railway (${result.cached ? 'cached' : 'fresh'})`);
-
-          // Convert to local storage format
-          const peerData = {};
-          result.data.forEach(answer => {
-              if (!peerData[answer.username]) {
-                  peerData[answer.username] = { answers: {} };
-              }
-              peerData[answer.username].answers[answer.question_id] = {
-                  value: answer.answer_value,
-                  timestamp: answer.timestamp
-              };
-          });
-
-          // Update local storage
-          const currentUser = localStorage.getItem('consensusUsername');
-          for (const [username, userData] of Object.entries(peerData)) {
-              if (username !== currentUser) {
-                  const key = `answers_${username}`;
-                  const existing = JSON.parse(localStorage.getItem(key) || '{}');
-
-                  // Merge with existing data
-                  Object.assign(existing, userData.answers);
-                  localStorage.setItem(key, JSON.stringify(existing));
-              }
+          const summary = await performMerkleSync();
+          if (summary) {
+              console.log('Merkle sync summary:', summary);
           }
-
-          // Update timestamp display
-          if (typeof updatePeerDataTimestamp === 'function') {
-              updatePeerDataTimestamp();
-          }
-
-          return peerData;
-
+          return buildPeerDataSnapshot();
       } catch (error) {
-          console.error('Railway pull failed:', error);
-          // Fall back to direct Supabase
+          console.error('Railway Merkle sync failed:', error);
+          // Fall back to direct Supabase for resilience
           return pullPeerDataFromSupabase();
       }
   }
@@ -370,7 +666,8 @@
       pullPeerData: pullPeerDataFromRailway,
       getStats: getQuestionStats,
       batchSubmit: batchSubmitViaRailway,
-      isConnected: () => wsConnected
+      isConnected: () => wsConnected,
+      getLastSyncSummary: () => lastSyncSummary
   };
 
   console.log('🚂 Railway client loaded. Set USE_RAILWAY=true to enable.');


### PR DESCRIPTION
## Summary
- add shared sync utilities with md5 hashing and manifest cache management on the server
- expose manifest, unit, and lesson endpoints with WebSocket updates and client-side Merkle reconciliation
- introduce browser hash helpers and assert-based node test script for the no-build workflow

## Testing
- node test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4892289a4832cb276ea904f0e89aa