### PR TITLE
Restore peer answer event dispatch

### DIFF
--- a/railway_client.js
+++ b/railway_client.js
@@ -155,6 +155,19 @@
       }
 
       try {
+          window.dispatchEvent(new CustomEvent('peer:answer', {
+              detail: {
+                  username: normalized.username,
+                  question_id: normalized.question_id,
+                  answer_value: normalized.answer_value,
+                  timestamp: normalized.timestamp
+              }
+          }));
+      } catch (error) {
+          console.warn("Failed to dispatch peer:answer event", error);
+      }
+
+      try {
           if (window.spriteManager && typeof window.checkIfAnswerCorrect === 'function') {
               const isCorrect = window.checkIfAnswerCorrect(normalized.question_id, normalized.answer_value);
               window.spriteManager.handlePeerAnswer(normalized.username, isCorrect);


### PR DESCRIPTION
## Summary
- dispatch the `peer:answer` custom event when merkle-sync applies a peer's answer
- ensure peer sprite reactions remain triggered even when sprites update directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5bc823d84832c82cf0aee373832ed